### PR TITLE
Implement functional dashboard pages with API stubs

### DIFF
--- a/app/(dashboard)/datasets/page.tsx
+++ b/app/(dashboard)/datasets/page.tsx
@@ -1,3 +1,34 @@
+'use client';
+import useSWR from 'swr';
+
+type Dataset = {
+  id: string;
+  name: string;
+  description: string;
+  rows: number;
+  updated: string;
+};
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
 export default function DatasetsPage() {
-  return <div>Data catalog coming soon.</div>;
+  const { data, error } = useSWR<{ datasets: Dataset[] }>(
+    '/api/datasets',
+    fetcher
+  );
+  if (error) return <div>Failed to load datasets.</div>;
+  if (!data) return <div>Loading datasets...</div>;
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {data.datasets.map((d) => (
+        <div key={d.id} className="border border-slate-800 rounded p-4">
+          <h2 className="font-semibold">{d.name}</h2>
+          <p className="text-sm text-slate-400">{d.description}</p>
+          <p className="text-xs text-slate-500 mt-2">
+            Rows: {d.rows.toLocaleString()} • Updated {d.updated}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
 }

--- a/app/(dashboard)/insights/page.tsx
+++ b/app/(dashboard)/insights/page.tsx
@@ -1,3 +1,33 @@
+'use client';
+import useSWR from 'swr';
+
+type Insight = {
+  id: string;
+  title: string;
+  description: string;
+  createdAt: number;
+};
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
 export default function InsightsPage() {
-  return <div>Saved insights will appear here.</div>;
+  const { data, error } = useSWR<{ insights: Insight[] }>(
+    '/api/insights',
+    fetcher
+  );
+  if (error) return <div>Failed to load insights.</div>;
+  if (!data) return <div>Loading insights...</div>;
+  return (
+    <div className="grid gap-4">
+      {data.insights.map((i) => (
+        <div key={i.id} className="border border-slate-800 rounded p-4">
+          <h2 className="font-semibold">{i.title}</h2>
+          <p className="text-sm text-slate-400">{i.description}</p>
+          <p className="text-xs text-slate-500 mt-2">
+            {new Date(i.createdAt).toLocaleDateString()}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
 }

--- a/app/(dashboard)/saved/page.tsx
+++ b/app/(dashboard)/saved/page.tsx
@@ -1,5 +1,31 @@
+'use client';
+import useSWR from 'swr';
+
+type SavedItem = {
+  id: string;
+  question: string;
+  createdAt: number;
+};
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
 export default function SavedPage() {
+  const { data, error } = useSWR<{ saved: SavedItem[] }>(
+    '/api/saved',
+    fetcher
+  );
+  if (error) return <div>Failed to load saved results.</div>;
+  if (!data) return <div>Loading saved results...</div>;
   return (
-    <div className="text-slate-300">Saved results coming soon.</div>
+    <ul className="space-y-2">
+      {data.saved.map((item) => (
+        <li key={item.id} className="border border-slate-800 rounded p-4">
+          <p className="font-medium">{item.question}</p>
+          <p className="text-xs text-slate-500 mt-1">
+            {new Date(item.createdAt).toLocaleDateString()}
+          </p>
+        </li>
+      ))}
+    </ul>
   );
 }

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -1,3 +1,28 @@
+'use client';
+import useSWR from 'swr';
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
 export default function SettingsPage() {
-  return <div>Settings placeholder.</div>;
+  const { data, error } = useSWR('/api/me', fetcher);
+  if (error) return <div>Failed to load settings.</div>;
+  if (!data) return <div>Loading settings...</div>;
+  return (
+    <div className="grid gap-6 max-w-md">
+      <section>
+        <h2 className="font-semibold mb-2">Profile</h2>
+        <p className="text-sm">{data.profile.name}</p>
+        <p className="text-sm text-slate-400">{data.profile.email}</p>
+      </section>
+      <section>
+        <h2 className="font-semibold mb-2">Preferences</h2>
+        <ul className="text-sm text-slate-300 space-y-1">
+          <li>Timezone: {data.preferences.timezone}</li>
+          <li>Currency: {data.preferences.currency}</li>
+          <li>Number format: {data.preferences.numberFormat}</li>
+          <li>Default window: {data.preferences.defaultWindow}</li>
+        </ul>
+      </section>
+    </div>
+  );
 }

--- a/app/(dashboard)/support/page.tsx
+++ b/app/(dashboard)/support/page.tsx
@@ -1,3 +1,63 @@
+'use client';
+import { FormEvent, useState } from 'react';
+
 export default function SupportPage() {
-  return <div>Help and FAQ coming soon.</div>;
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle');
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setStatus('sending');
+    try {
+      const res = await fetch('/api/support', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, message }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      setStatus('sent');
+      setEmail('');
+      setMessage('');
+    } catch {
+      setStatus('error');
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-md grid gap-2">
+      <label className="flex flex-col gap-1">
+        <span className="text-sm">Email</span>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className="p-2 rounded bg-slate-800"
+        />
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="text-sm">Message</span>
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          required
+          className="p-2 rounded bg-slate-800 h-32"
+        />
+      </label>
+      <button
+        type="submit"
+        disabled={status === 'sending'}
+        className="bg-blue-600 hover:bg-blue-700 rounded p-2"
+      >
+        {status === 'sending' ? 'Sending…' : 'Submit'}
+      </button>
+      {status === 'sent' && (
+        <p className="text-green-400 text-sm">Thanks for reaching out!</p>
+      )}
+      {status === 'error' && (
+        <p className="text-red-400 text-sm">Submission failed.</p>
+      )}
+    </form>
+  );
 }

--- a/app/api/datasets/route.ts
+++ b/app/api/datasets/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+
+const datasets = [
+  {
+    id: 'awards',
+    name: 'Contract Awards',
+    description: 'All federal contract awards with basic details.',
+    rows: 125000,
+    updated: '2024-01-01',
+  },
+  {
+    id: 'suppliers',
+    name: 'Supplier Directory',
+    description: 'Registered suppliers with contact information.',
+    rows: 32000,
+    updated: '2024-02-15',
+  },
+];
+
+export async function GET() {
+  return NextResponse.json({ datasets });
+}

--- a/app/api/insights/route.ts
+++ b/app/api/insights/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+
+const insights = [
+  {
+    id: 'top-suppliers',
+    title: 'Top suppliers by revenue',
+    description: 'Identifies suppliers with the highest revenue in the last fiscal year.',
+    createdAt: Date.now() - 86400000 * 2,
+  },
+  {
+    id: 'spend-trend',
+    title: 'Quarterly spend trend',
+    description: 'Visualizes spending trends over the past 4 quarters.',
+    createdAt: Date.now() - 86400000 * 7,
+  },
+];
+
+export async function GET() {
+  return NextResponse.json({ insights });
+}

--- a/app/api/saved/route.ts
+++ b/app/api/saved/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+
+const saved = [
+  {
+    id: 'q1',
+    question: 'Top 10 NIINs by revenue in 2022',
+    createdAt: Date.now() - 86400000 * 3,
+  },
+  {
+    id: 'q2',
+    question: 'Average unit price for NIIN 000000057',
+    createdAt: Date.now() - 86400000 * 15,
+  },
+];
+
+export async function GET() {
+  return NextResponse.json({ saved });
+}

--- a/app/api/support/route.ts
+++ b/app/api/support/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  try {
+    const { email, message } = await req.json();
+    if (!email || !message) {
+      return NextResponse.json({ ok: false }, { status: 400 });
+    }
+    // Here we would normally persist the request or send an email.
+    console.log('Support request', email, message);
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- Add dataset, insight, saved, and support API routes returning stub data
- Replace placeholder dashboard pages with data-driven components
- Include simple contact form that posts to `/api/support`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfc2ade5c48329a330232b7ee3f865