### PR TITLE
Enable editing and creation for dashboard data

### DIFF
--- a/app/(dashboard)/datasets/page.tsx
+++ b/app/(dashboard)/datasets/page.tsx
@@ -1,3 +1,111 @@
+'use client';
+import { FormEvent, useState } from 'react';
+import useSWR from 'swr';
+
+type Dataset = {
+  id: string;
+  name: string;
+  description: string;
+  rows: number;
+  updated: string;
+};
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
 export default function DatasetsPage() {
-  return <div>Data catalog coming soon.</div>;
+  const { data, error, mutate } = useSWR<{ datasets: Dataset[] }>(
+    '/api/datasets',
+    fetcher
+  );
+  const [form, setForm] = useState({
+    name: '',
+    description: '',
+    rows: '',
+    updated: '',
+  });
+  const [status, setStatus] = useState<'idle' | 'saving' | 'error'>('idle');
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setStatus('saving');
+    try {
+      const res = await fetch('/api/datasets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...form,
+          rows: Number(form.rows),
+        }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      setForm({ name: '', description: '', rows: '', updated: '' });
+      await mutate();
+      setStatus('idle');
+    } catch {
+      setStatus('error');
+    }
+  }
+
+  if (error) return <div>Failed to load datasets.</div>;
+  if (!data) return <div>Loading datasets...</div>;
+
+  return (
+    <div className="grid gap-6">
+      <form onSubmit={handleSubmit} className="grid gap-2 max-w-md">
+        <input
+          type="text"
+          placeholder="Name"
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+          className="p-2 rounded bg-slate-800"
+          required
+        />
+        <input
+          type="text"
+          placeholder="Description"
+          value={form.description}
+          onChange={(e) => setForm({ ...form, description: e.target.value })}
+          className="p-2 rounded bg-slate-800"
+          required
+        />
+        <input
+          type="number"
+          placeholder="Rows"
+          value={form.rows}
+          onChange={(e) => setForm({ ...form, rows: e.target.value })}
+          className="p-2 rounded bg-slate-800"
+          required
+        />
+        <input
+          type="date"
+          placeholder="Updated"
+          value={form.updated}
+          onChange={(e) => setForm({ ...form, updated: e.target.value })}
+          className="p-2 rounded bg-slate-800"
+          required
+        />
+        <button
+          type="submit"
+          disabled={status === 'saving'}
+          className="bg-blue-600 hover:bg-blue-700 rounded p-2"
+        >
+          {status === 'saving' ? 'Saving…' : 'Add Dataset'}
+        </button>
+        {status === 'error' && (
+          <p className="text-red-400 text-sm">Failed to add dataset.</p>
+        )}
+      </form>
+      <div className="grid gap-4 md:grid-cols-2">
+        {data.datasets.map((d) => (
+          <div key={d.id} className="border border-slate-800 rounded p-4">
+            <h2 className="font-semibold">{d.name}</h2>
+            <p className="text-sm text-slate-400">{d.description}</p>
+            <p className="text-xs text-slate-500 mt-2">
+              Rows: {d.rows.toLocaleString()} • Updated {d.updated}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/app/(dashboard)/insights/page.tsx
+++ b/app/(dashboard)/insights/page.tsx
@@ -1,3 +1,87 @@
+'use client';
+import { FormEvent, useState } from 'react';
+import useSWR from 'swr';
+
+type Insight = {
+  id: string;
+  title: string;
+  description: string;
+  createdAt: number;
+};
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
 export default function InsightsPage() {
-  return <div>Saved insights will appear here.</div>;
+  const { data, error, mutate } = useSWR<{ insights: Insight[] }>(
+    '/api/insights',
+    fetcher
+  );
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [status, setStatus] = useState<'idle' | 'saving' | 'error'>('idle');
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setStatus('saving');
+    try {
+      const res = await fetch('/api/insights', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, description }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      setTitle('');
+      setDescription('');
+      await mutate();
+      setStatus('idle');
+    } catch {
+      setStatus('error');
+    }
+  }
+
+  if (error) return <div>Failed to load insights.</div>;
+  if (!data) return <div>Loading insights...</div>;
+
+  return (
+    <div className="grid gap-6">
+      <form onSubmit={handleSubmit} className="grid gap-2 max-w-md">
+        <input
+          type="text"
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="p-2 rounded bg-slate-800"
+          required
+        />
+        <textarea
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="p-2 rounded bg-slate-800 h-24"
+          required
+        />
+        <button
+          type="submit"
+          disabled={status === 'saving'}
+          className="bg-blue-600 hover:bg-blue-700 rounded p-2"
+        >
+          {status === 'saving' ? 'Saving…' : 'Add Insight'}
+        </button>
+        {status === 'error' && (
+          <p className="text-red-400 text-sm">Failed to add insight.</p>
+        )}
+      </form>
+      <div className="grid gap-4">
+        {data.insights.map((i) => (
+          <div key={i.id} className="border border-slate-800 rounded p-4">
+            <h2 className="font-semibold">{i.title}</h2>
+            <p className="text-sm text-slate-400">{i.description}</p>
+            <p className="text-xs text-slate-500 mt-2">
+              {new Date(i.createdAt).toLocaleDateString()}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/app/(dashboard)/saved/page.tsx
+++ b/app/(dashboard)/saved/page.tsx
@@ -1,5 +1,76 @@
+'use client';
+import { FormEvent, useState } from 'react';
+import useSWR from 'swr';
+
+type SavedItem = {
+  id: string;
+  question: string;
+  createdAt: number;
+};
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
 export default function SavedPage() {
+  const { data, error, mutate } = useSWR<{ saved: SavedItem[] }>(
+    '/api/saved',
+    fetcher
+  );
+  const [question, setQuestion] = useState('');
+  const [status, setStatus] = useState<'idle' | 'saving' | 'error'>('idle');
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setStatus('saving');
+    try {
+      const res = await fetch('/api/saved', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      setQuestion('');
+      await mutate();
+      setStatus('idle');
+    } catch {
+      setStatus('error');
+    }
+  }
+
+  if (error) return <div>Failed to load saved results.</div>;
+  if (!data) return <div>Loading saved results...</div>;
+
   return (
-    <div className="text-slate-300">Saved results coming soon.</div>
+    <div className="grid gap-6">
+      <form onSubmit={handleSubmit} className="grid gap-2 max-w-md">
+        <input
+          type="text"
+          placeholder="Question"
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          className="p-2 rounded bg-slate-800"
+          required
+        />
+        <button
+          type="submit"
+          disabled={status === 'saving'}
+          className="bg-blue-600 hover:bg-blue-700 rounded p-2"
+        >
+          {status === 'saving' ? 'Saving…' : 'Save Question'}
+        </button>
+        {status === 'error' && (
+          <p className="text-red-400 text-sm">Failed to save question.</p>
+        )}
+      </form>
+      <ul className="space-y-2">
+        {data.saved.map((item) => (
+          <li key={item.id} className="border border-slate-800 rounded p-4">
+            <p className="font-medium">{item.question}</p>
+            <p className="text-xs text-slate-500 mt-1">
+              {new Date(item.createdAt).toLocaleDateString()}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -1,3 +1,118 @@
+'use client';
+import { FormEvent, useEffect, useState } from 'react';
+import useSWR from 'swr';
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
 export default function SettingsPage() {
-  return <div>Settings placeholder.</div>;
+  const { data, error, mutate } = useSWR('/api/me', fetcher);
+  const [profile, setProfile] = useState({ name: '', email: '' });
+  const [preferences, setPreferences] = useState({
+    timezone: '',
+    currency: '',
+    numberFormat: '',
+    defaultWindow: '',
+  });
+  const [status, setStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+
+  useEffect(() => {
+    if (data) {
+      setProfile(data.profile);
+      setPreferences(data.preferences);
+    }
+  }, [data]);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setStatus('saving');
+    try {
+      const res = await fetch('/api/me', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ profile, preferences }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      await mutate();
+      setStatus('saved');
+    } catch {
+      setStatus('error');
+    }
+  }
+
+  if (error) return <div>Failed to load settings.</div>;
+  if (!data) return <div>Loading settings...</div>;
+
+  return (
+    <form onSubmit={handleSubmit} className="grid gap-6 max-w-md">
+      <section className="grid gap-2">
+        <h2 className="font-semibold">Profile</h2>
+        <input
+          type="text"
+          value={profile.name}
+          onChange={(e) => setProfile({ ...profile, name: e.target.value })}
+          className="p-2 rounded bg-slate-800"
+          required
+        />
+        <input
+          type="email"
+          value={profile.email}
+          onChange={(e) => setProfile({ ...profile, email: e.target.value })}
+          className="p-2 rounded bg-slate-800"
+          required
+        />
+      </section>
+      <section className="grid gap-2">
+        <h2 className="font-semibold">Preferences</h2>
+        <input
+          type="text"
+          value={preferences.timezone}
+          onChange={(e) =>
+            setPreferences({ ...preferences, timezone: e.target.value })
+          }
+          className="p-2 rounded bg-slate-800"
+          required
+        />
+        <input
+          type="text"
+          value={preferences.currency}
+          onChange={(e) =>
+            setPreferences({ ...preferences, currency: e.target.value })
+          }
+          className="p-2 rounded bg-slate-800"
+          required
+        />
+        <input
+          type="text"
+          value={preferences.numberFormat}
+          onChange={(e) =>
+            setPreferences({ ...preferences, numberFormat: e.target.value })
+          }
+          className="p-2 rounded bg-slate-800"
+          required
+        />
+        <input
+          type="text"
+          value={preferences.defaultWindow}
+          onChange={(e) =>
+            setPreferences({ ...preferences, defaultWindow: e.target.value })
+          }
+          className="p-2 rounded bg-slate-800"
+          required
+        />
+      </section>
+      <button
+        type="submit"
+        disabled={status === 'saving'}
+        className="bg-blue-600 hover:bg-blue-700 rounded p-2"
+      >
+        {status === 'saving' ? 'Saving…' : 'Save'}
+      </button>
+      {status === 'saved' && (
+        <p className="text-green-400 text-sm">Settings saved.</p>
+      )}
+      {status === 'error' && (
+        <p className="text-red-400 text-sm">Failed to save settings.</p>
+      )}
+    </form>
+  );
 }

--- a/app/(dashboard)/support/page.tsx
+++ b/app/(dashboard)/support/page.tsx
@@ -1,3 +1,63 @@
+'use client';
+import { FormEvent, useState } from 'react';
+
 export default function SupportPage() {
-  return <div>Help and FAQ coming soon.</div>;
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle');
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setStatus('sending');
+    try {
+      const res = await fetch('/api/support', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, message }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      setStatus('sent');
+      setEmail('');
+      setMessage('');
+    } catch {
+      setStatus('error');
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-md grid gap-2">
+      <label className="flex flex-col gap-1">
+        <span className="text-sm">Email</span>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className="p-2 rounded bg-slate-800"
+        />
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="text-sm">Message</span>
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          required
+          className="p-2 rounded bg-slate-800 h-32"
+        />
+      </label>
+      <button
+        type="submit"
+        disabled={status === 'sending'}
+        className="bg-blue-600 hover:bg-blue-700 rounded p-2"
+      >
+        {status === 'sending' ? 'Sending…' : 'Submit'}
+      </button>
+      {status === 'sent' && (
+        <p className="text-green-400 text-sm">Thanks for reaching out!</p>
+      )}
+      {status === 'error' && (
+        <p className="text-red-400 text-sm">Submission failed.</p>
+      )}
+    </form>
+  );
 }

--- a/app/api/datasets/route.ts
+++ b/app/api/datasets/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+
+type Dataset = {
+  id: string;
+  name: string;
+  description: string;
+  rows: number;
+  updated: string;
+};
+
+let datasets: Dataset[] = [
+  {
+    id: 'awards',
+    name: 'Contract Awards',
+    description: 'All federal contract awards with basic details.',
+    rows: 125000,
+    updated: '2024-01-01',
+  },
+  {
+    id: 'suppliers',
+    name: 'Supplier Directory',
+    description: 'Registered suppliers with contact information.',
+    rows: 32000,
+    updated: '2024-02-15',
+  },
+];
+
+export async function GET() {
+  return NextResponse.json({ datasets });
+}
+
+export async function POST(req: Request) {
+  try {
+    const { name, description, rows, updated } = await req.json();
+    if (!name || !description || rows == null || !updated) {
+      return NextResponse.json({ ok: false }, { status: 400 });
+    }
+    const dataset: Dataset = {
+      id: Date.now().toString(),
+      name,
+      description,
+      rows: Number(rows),
+      updated,
+    };
+    datasets.push(dataset);
+    return NextResponse.json({ dataset }, { status: 201 });
+  } catch {
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+}

--- a/app/api/insights/route.ts
+++ b/app/api/insights/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+
+type Insight = {
+  id: string;
+  title: string;
+  description: string;
+  createdAt: number;
+};
+
+let insights: Insight[] = [
+  {
+    id: 'top-suppliers',
+    title: 'Top suppliers by revenue',
+    description:
+      'Identifies suppliers with the highest revenue in the last fiscal year.',
+    createdAt: Date.now() - 86400000 * 2,
+  },
+  {
+    id: 'spend-trend',
+    title: 'Quarterly spend trend',
+    description: 'Visualizes spending trends over the past 4 quarters.',
+    createdAt: Date.now() - 86400000 * 7,
+  },
+];
+
+export async function GET() {
+  return NextResponse.json({ insights });
+}
+
+export async function POST(req: Request) {
+  try {
+    const { title, description } = await req.json();
+    if (!title || !description) {
+      return NextResponse.json({ ok: false }, { status: 400 });
+    }
+    const insight: Insight = {
+      id: Date.now().toString(),
+      title,
+      description,
+      createdAt: Date.now(),
+    };
+    insights.push(insight);
+    return NextResponse.json({ insight }, { status: 201 });
+  } catch {
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+}

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -1,13 +1,36 @@
 import { NextResponse } from 'next/server';
 
+type Me = {
+  profile: { name: string; email: string };
+  preferences: {
+    timezone: string;
+    currency: string;
+    numberFormat: string;
+    defaultWindow: string;
+  };
+};
+
+let me: Me = {
+  profile: { name: 'Demo User', email: 'demo@example.com' },
+  preferences: {
+    timezone: 'UTC',
+    currency: 'USD',
+    numberFormat: '1,234.56',
+    defaultWindow: 'last 12 months',
+  },
+};
+
 export async function GET() {
-  return NextResponse.json({
-    profile: { name: 'Demo User', email: 'demo@example.com' },
-    preferences: {
-      timezone: 'UTC',
-      currency: 'USD',
-      numberFormat: '1,234.56',
-      defaultWindow: 'last 12 months',
-    },
-  });
+  return NextResponse.json(me);
+}
+
+export async function PUT(req: Request) {
+  try {
+    const { profile, preferences } = await req.json();
+    if (profile) me.profile = profile;
+    if (preferences) me.preferences = preferences;
+    return NextResponse.json(me);
+  } catch {
+    return NextResponse.json({ ok: false }, { status: 400 });
+  }
 }

--- a/app/api/saved/route.ts
+++ b/app/api/saved/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+
+type SavedItem = {
+  id: string;
+  question: string;
+  createdAt: number;
+};
+
+let saved: SavedItem[] = [
+  {
+    id: 'q1',
+    question: 'Top 10 NIINs by revenue in 2022',
+    createdAt: Date.now() - 86400000 * 3,
+  },
+  {
+    id: 'q2',
+    question: 'Average unit price for NIIN 000000057',
+    createdAt: Date.now() - 86400000 * 15,
+  },
+];
+
+export async function GET() {
+  return NextResponse.json({ saved });
+}
+
+export async function POST(req: Request) {
+  try {
+    const { question } = await req.json();
+    if (!question) {
+      return NextResponse.json({ ok: false }, { status: 400 });
+    }
+    const item: SavedItem = {
+      id: Date.now().toString(),
+      question,
+      createdAt: Date.now(),
+    };
+    saved.push(item);
+    return NextResponse.json({ item }, { status: 201 });
+  } catch {
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+}

--- a/app/api/support/route.ts
+++ b/app/api/support/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  try {
+    const { email, message } = await req.json();
+    if (!email || !message) {
+      return NextResponse.json({ ok: false }, { status: 400 });
+    }
+    // Here we would normally persist the request or send an email.
+    console.log('Support request', email, message);
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- Allow editing of user profile and preferences via settings form
- Add forms for creating datasets, insights, and saved questions with POST API routes
- Extend API routes to store and mutate data in memory

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfc2ade5c48329a330232b7ee3f865