### PR TITLE
Export column and row types for DataTable

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,11 +1,14 @@
+export type Column = { name: string; type?: string };
+export type Row = any[];
+
 export type ChatResp = { mode: 'chat'; answer: string };
 
 export type SqlResp = {
   mode: 'sql';
   sql?: string;
   result?: {
-    columns: { name: string; type?: string }[];
-    rows: any[]; // treat as any[][]
+    columns: Column[];
+    rows: Row[]; // treat as any[][]
   };
 };
 


### PR DESCRIPTION
## Summary
- export `Column` and `Row` types in `lib/types` and reuse them in `SqlResp`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfc5b8a6248329862dc18af2dc3faa