### PR TITLE
Improve ask API handling

### DIFF
--- a/app/(dashboard)/chat/page.tsx
+++ b/app/(dashboard)/chat/page.tsx
@@ -28,7 +28,19 @@ export default function ChatPage() {
     setBusy(true);
     try {
       const resp = await ask(question);
-      if (resp.mode === 'chat') {
+      if ((resp as any).error) {
+        setMessages((m) => [
+          ...m,
+          {
+            id: uid(),
+            role: 'assistant',
+            content: 'Request failed',
+            error: (resp as any).error,
+            createdAt: Date.now(),
+          },
+        ]);
+        setLastData(null);
+      } else if (resp.mode === 'chat') {
         setMessages((m) => [
           ...m,
           { id: uid(), role: 'assistant', content: resp.answer, createdAt: Date.now() },
@@ -40,6 +52,18 @@ export default function ChatPage() {
           { id: uid(), role: 'assistant', content: 'Here are the results.', createdAt: Date.now() },
         ]);
         setLastData(resp);
+      } else {
+        setMessages((m) => [
+          ...m,
+          {
+            id: uid(),
+            role: 'assistant',
+            content: 'Unexpected response',
+            error: JSON.stringify(resp),
+            createdAt: Date.now(),
+          },
+        ]);
+        setLastData(null);
       }
     } catch (e: any) {
       setMessages((m) => [

--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  try {
+    const payload = await req.json();
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/ask`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const text = await res.text();
+    return new NextResponse(text, {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('Lambda request failed', err);
+    return NextResponse.json({ error: 'Upstream request failed' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- proxy POST /api/ask through Next.js API route
- log API status and parse lambda responses safely
- surface upstream errors in chat view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfc7c9c4688329b3c8cb8599b4af8f